### PR TITLE
Added restriction base to latest example.

### DIFF
--- a/Development/Second production release/Examples2.md
+++ b/Development/Second production release/Examples2.md
@@ -95,7 +95,7 @@ In <requirements> there can only be one entity node (it can have multiple IFC En
 			<propertyset>Anas</propertyset>
 			<name>Codice WBS</name>
 			<value>
-				<xs:restriction>
+				<xs:restriction base="xs:integer">
 				  <xs:minInclusive value="0"/>
 				  <xs:maxInclusive value="120"/>
 				</xs:restriction>


### PR DESCRIPTION
In order to process the correct comparison logic of minInclusive and maxInclusive it's important to have the base data type declared.