### PR TITLE
The `info` type should probably contain a sequence

### DIFF
--- a/Development/Third production release/ids.xsd
+++ b/Development/Third production release/ids.xsd
@@ -8,7 +8,7 @@
 					<xs:sequence>
 						<xs:element name="info">
 							<xs:complexType>
-								<xs:choice>
+								<xs:sequence>
 									<xs:element name="ifcversion"/>
 									<xs:element name="description" minOccurs="0"/>
 									<xs:element name="author" minOccurs="0"/>
@@ -17,7 +17,7 @@
 									<xs:element name="date" type="xs:date"/>
 									<xs:element name="purpose" minOccurs="0"/>
 									<xs:element name="milestone" minOccurs="0"/>
-								</xs:choice>
+								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
 					</xs:sequence>


### PR DESCRIPTION
I think the intended usage of info sub-elements was a sequence.