### PR TITLE
Updated PartOf Enumeration and initial doc.

### DIFF
--- a/Development/0.6/ids_06.xsd
+++ b/Development/0.6/ids_06.xsd
@@ -174,15 +174,22 @@
 					<xs:attribute name="entity" use="required">
 						<xs:simpleType>
 							<xs:restriction base="xs:string">
-								<xs:enumeration value="IfcElementAssembly"/>
-								<xs:enumeration value="IfcGroup"/>
-								<xs:enumeration value="IfcSystem"/>
+								<xs:enumeration value="IfcAsset"/>
 								<xs:enumeration value="IfcBuildingSystem"/>
 								<xs:enumeration value="IfcBuiltSystem"/>
+								<xs:enumeration value="IfcCondition"/>
+								<xs:enumeration value="IfcDistributionCircuit"/>
 								<xs:enumeration value="IfcDistributionSystem"/>
-								<xs:enumeration value="IfcZone"/>
-								<xs:enumeration value="IfcAsset"/>
+								<xs:enumeration value="IfcElectricalCircuit"/>
+								<xs:enumeration value="IfcElementAssembly"/>
+								<xs:enumeration value="IfcGroup"/>
 								<xs:enumeration value="IfcInventory"/>
+								<xs:enumeration value="IfcStructuralAnalysisModel"/>
+								<xs:enumeration value="IfcStructuralLoadCase"/>
+								<xs:enumeration value="IfcStructuralLoadGroup"/>
+								<xs:enumeration value="IfcStructuralResultGroup"/>
+								<xs:enumeration value="IfcSystem"/>
+								<xs:enumeration value="IfcZone"/>
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>

--- a/Documentation/PartOf.md
+++ b/Documentation/PartOf.md
@@ -1,10 +1,20 @@
-# Valid PartOf Containers
+# PartOf facet
 
-The use of PartOf in different schema versions shoud be compatible with the relevant classes as follows.
+The `PartOf` facet is designed to check that an element is defined to be part of a predefined set of aggregators.
 
-## Groups inheritance tree
+The `PartOf.Entity` property identifies the type of the aggregator. 
 
-The following classes are used to defined grouping via `IfcRelAssignsToGroup`.
+The predefined aggregation types are:
+
+- `IfcGroup` and its descendant classes, and
+- `IfcElementAssembly`
+
+## IfcGroup
+
+When `PartOf.Entity`  is any of the descendant classes of 'IfcGroup', the facet is satisfied when an entity belongs 
+to the a group via one or more instances of `IfcRelAssignsToGroup`.
+
+The value of `PartOf.Entity` should depend on the schema version, as follows: 
 
 | IFC2x3                        | IFC4                            | IFC4x3                           |
 | ----------------------------- | ------------------------------- | -------------------------------- |
@@ -24,14 +34,16 @@ The following classes are used to defined grouping via `IfcRelAssignsToGroup`.
 | ~~ IfcStructuralAnalysisModel | ~~ IfcStructuralAnalysisModel   | ~~ IfcStructuralAnalysisModel    |
 | ~ IfcZone                     | ~~ IfcZone                      | ~~ IfcZone                       |
 
-## Other forms 
+## IfcElementAssembly
 
-It is also possible to define elements belonging to an `IfcElementAssembly` via `IfcRelAggregates`.
+When `PartOf.Entity` is `IfcElementAssembly`, the facet is satisfied when an entity belongs 
+to at least one IfcElementAssembly via instances of `IfcRelAggregates`.
 
 ## Enumeration
 
-The entire alphabetical list of valid strings is:
+The entire alphabetical list of valid strings for `PartOf.Entity` is:
 
+```
 IfcAsset
 IfcBuildingSystem
 IfcBuiltSystem
@@ -48,3 +60,4 @@ IfcStructuralLoadGroup
 IfcStructuralResultGroup
 IfcSystem
 IfcZone
+```

--- a/Documentation/PartOf.md
+++ b/Documentation/PartOf.md
@@ -1,18 +1,16 @@
 # PartOf facet
 
-The `PartOf` facet is designed to check that an element is defined to be part of a predefined set of aggregators.
+The `PartOf` facet is designed to check that an element is part of a predefined set of aggregators through the appropriate relationship.
 
-The `PartOf.Entity` property identifies the type of the aggregator. 
+The `PartOf.Entity` property identifies the type of the aggregator, and predefined aggregation types are:
 
-The predefined aggregation types are:
-
-- `IfcGroup` and its descendant classes, and
+- `IfcGroup` (including derived classes), or
 - `IfcElementAssembly`
 
 ## IfcGroup
 
-When `PartOf.Entity`  is any of the descendant classes of 'IfcGroup', the facet is satisfied when an entity belongs 
-to the a group via one or more instances of `IfcRelAssignsToGroup`.
+When `PartOf.Entity`  is any of the derived classes of `IfcGroup`, the facet is satisfied when an entity 
+belongs to a group via one or more instances of `IfcRelAssignsToGroup`.
 
 The value of `PartOf.Entity` should depend on the schema version, as follows: 
 
@@ -34,6 +32,9 @@ The value of `PartOf.Entity` should depend on the schema version, as follows:
 | ~~ IfcStructuralAnalysisModel | ~~ IfcStructuralAnalysisModel   | ~~ IfcStructuralAnalysisModel    |
 | ~ IfcZone                     | ~~ IfcZone                      | ~~ IfcZone                       |
 
+The clause implementation should consider inheritance (e.g. being part of a `IfcBuildingSystem` satisfies a request 
+to be part of its superclass `IfcSystem`).
+
 ## IfcElementAssembly
 
 When `PartOf.Entity` is `IfcElementAssembly`, the facet is satisfied when an entity belongs 
@@ -41,7 +42,7 @@ to at least one IfcElementAssembly via instances of `IfcRelAggregates`.
 
 ## Enumeration
 
-The entire alphabetical list of valid strings for `PartOf.Entity` is:
+The entire alphabetical list of valid values for the `Entity` property is:
 
 ```
 IfcAsset

--- a/Documentation/PartOf.md
+++ b/Documentation/PartOf.md
@@ -1,0 +1,50 @@
+# Valid PartOf Containers
+
+The use of PartOf in different schema versions shoud be compatible with the relevant classes as follows.
+
+## Groups inheritance tree
+
+The following classes are used to defined grouping via `IfcRelAssignsToGroup`.
+
+| IFC2x3                        | IFC4                            | IFC4x3                           |
+| ----------------------------- | ------------------------------- | -------------------------------- |
+| IfcGroup                      | IfcGroup                        | IfcGroup                         |
+| ~ IfcAsset                    | ~ IfcAsset                      | ~ IfcAsset                       |
+| ~ IfcCondition                |                                 |                                  |
+| ~ IfcInventory                | ~ IfcInventory                  | ~ IfcInventory                   |
+| ~ IfcStructuralLoadGroup      | ~ IfcStructuralLoadGroup        | ~ IfcStructuralLoadGroup         |
+|                               | ~~ IfcStructuralLoadCase        | ~~ IfcStructuralLoadCase         |
+| ~ IfcStructuralResultGroup    | ~ IfcStructuralResultGroup      | ~ IfcStructuralResultGroup       |
+| ~ IfcSystem                   | ~ IfcSystem                     | ~ IfcSystem                      |
+|                               | ~~ IfcBuildingSystem            | ~~ IfcBuildingSystem             |
+|                               |                                 | ~~ IfcBuiltSystem                |
+|                               | ~~ IfcDistributionSystem        | ~~ IfcDistributionSystem         |
+|                               | ~~~ IfcDistributionCircuit      | ~~~ IfcDistributionCircuit       |
+| ~~ IfcElectricalCircuit       |                                 |                                  |
+| ~~ IfcStructuralAnalysisModel | ~~ IfcStructuralAnalysisModel   | ~~ IfcStructuralAnalysisModel    |
+| ~ IfcZone                     | ~~ IfcZone                      | ~~ IfcZone                       |
+
+## Other forms 
+
+It is also possible to define elements belonging to an `IfcElementAssembly` via `IfcRelAggregates`.
+
+## Enumeration
+
+The entire alphabetical list of valid strings is:
+
+IfcAsset
+IfcBuildingSystem
+IfcBuiltSystem
+IfcCondition
+IfcDistributionCircuit
+IfcDistributionSystem
+IfcElectricalCircuit
+IfcElementAssembly
+IfcGroup
+IfcInventory
+IfcStructuralAnalysisModel
+IfcStructuralLoadCase
+IfcStructuralLoadGroup
+IfcStructuralResultGroup
+IfcSystem
+IfcZone


### PR DESCRIPTION
Implementing PartOf I've noticed that there are a few classes missing from the enum.

These are needed since it's been agreed that IDS will need to work with versions 2x3 and 4 of the schema as well as 4x3.
I've also started a draft document on the facet.

I'm happy to restructure it, if there's guidance.