### PR TITLE
Fixing schema verification environment

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -15,19 +15,19 @@ class Build : NukeBuild
     [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
     readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
 
-    [PackageExecutable("ids-tool.CommandLine", "tools/net5.0/ids-tool.dll")] Tool BcfTool;
-    private string BcfToolPath => System.IO.Path.GetDirectoryName(ToolPathResolver.GetPackageExecutable("ids-tool.CommandLine", "tools/net5.0/ids-tool.dll"));
+    [PackageExecutable("ids-tool.CommandLine", "tools/net6.0/ids-tool.dll")] Tool BcfTool;
+    private string BcfToolPath => System.IO.Path.GetDirectoryName(ToolPathResolver.GetPackageExecutable("ids-tool.CommandLine", "tools/net6.0/ids-tool.dll"));
 
     Target CheckTestCases => _ => _
         .Executes(() =>
         {
             var schemaFile = Path.Combine(
                 RootDirectory,
-                "Development/0.6/ids_06.xsd"
+                "Development/0.9/ids_09.xsd"
                 );
             var inputFolder = Path.Combine(
                 RootDirectory,
-                "Development/0.6"
+                "Development/0.9"
                 );
             var arguments = $"check \"{inputFolder}\" -x \"{schemaFile}\"";
             BcfTool(arguments, workingDirectory: BcfToolPath);

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ids-tool.CommandLine" Version="1.0.4" />
-    <PackageReference Include="Nuke.Common" Version="6.0.3" />
+    <PackageReference Include="ids-tool.CommandLine" Version="1.0.7" />
+    <PackageReference Include="Nuke.Common" Version="6.2.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Github have updated the action environment.
This PR fixes the automated action that tests the example files against the schema for version 0.9