### PR TITLE
Added IFC4 schema

### DIFF
--- a/Documentation/testcases/ids/fail-required_specifications_need_at_least_one_applicable_entity_2_2.ids
+++ b/Documentation/testcases/ids/fail-required_specifications_need_at_least_one_applicable_entity_2_2.ids
@@ -3,7 +3,7 @@
         <title>Title</title>
     </info>
     <specifications>
-        <specification name="Name" ifcVersion="" minOccurs="1" maxOccurs="unbounded">
+        <specification name="Name" ifcVersion="IFC4" minOccurs="1" maxOccurs="unbounded">
             <applicability>
                 <entity>
                     <name>


### PR DESCRIPTION
Since the point of this test case (presumably) is to verify that the implementation detects that there are no ```IFCWALL``` in the IFC whilst the specification is REQUIRED, I think the spec should have the ```IFC4``` ```ifcVersion``` otherwise it will already fail on that.