### PR TITLE
Entity name should be UPPERCASE

### DIFF
--- a/Development/IDS_demo_BIM-basis-ILS.ids
+++ b/Development/IDS_demo_BIM-basis-ILS.ids
@@ -36,7 +36,7 @@
             <ids:applicability>
                 <ids:entity>
                     <ids:name>
-                        <ids:simpleValue>IfcBuildingStorey</ids:simpleValue>
+                        <ids:simpleValue>IFCBUILDINGSTOREY</ids:simpleValue>
                     </ids:name>
                 </ids:entity>
             </ids:applicability>


### PR DESCRIPTION
I've fixed a documentation file with an invalid Entity type name.

This might change in the future, depending on #132, but for the time being `IfcBuildingStorey` is invalid.