### PR TITLE
invalid attribute name

### DIFF
--- a/Development/IDS_aachen_example.ids
+++ b/Development/IDS_aachen_example.ids
@@ -17,7 +17,7 @@
             <ids:requirements>
                 <ids:attribute minOccurs="1">
                     <ids:name>
-                        <ids:simpleValue>name</ids:simpleValue>
+                        <ids:simpleValue>Name</ids:simpleValue>
                     </ids:name>
                 </ids:attribute>
             </ids:requirements>


### PR DESCRIPTION
Attribute name should match case with schema (in documentation files)

This might change in the future,
also depending from a parallel conversation happening on #132,
but for the time being 'name' is not a valid attribute name;
it should be capitalized ('Name').