### PR TITLE
Updated ids-tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/obj/
 .tmp/
 /build/.vs/
 /.nuke/temp/
+/.vs/

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -72,6 +72,8 @@
           "items": {
             "type": "string",
             "enum": [
+              "AuditDevelopment",
+              "AuditDocTestCases",
               "CheckTestCases"
             ]
           }
@@ -82,6 +84,8 @@
           "items": {
             "type": "string",
             "enum": [
+              "AuditDevelopment",
+              "AuditDocTestCases",
               "CheckTestCases"
             ]
           }

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ids-tool.CommandLine" Version="1.0.9" />
+    <PackageReference Include="ids-tool.CommandLine" Version="1.0.11" />
     <PackageReference Include="Nuke.Common" Version="6.2.1" />
   </ItemGroup>
 


### PR DESCRIPTION
hello @Moult, @berlotti 

I'm proposing an updated version of the audit tool that performs a more thorough audit of the repository. 

This configuration is checking:
- Development folder for schema and content 
- Documentation\testcases folder for schema compliance only (some files deliberately break content agreements).