### PR TITLE
Fix: cardinality of restriction not as intended.

### DIFF
--- a/Development/ids.xsd
+++ b/Development/ids.xsd
@@ -40,7 +40,7 @@
 		<xs:choice minOccurs="1">
 			<!-- place for potential additional rules for idsValue -->
 			<xs:element name="simpleValue" type="xs:string" minOccurs="1" maxOccurs="1"/>
-			<xs:element ref="xs:restriction" minOccurs="1" maxOccurs="unbounded"/>
+			<xs:element ref="xs:restriction" minOccurs="1" maxOccurs="1"/>
 		</xs:choice>
 	</xs:complexType>
 	<xs:complexType name="classificationType">


### PR DESCRIPTION
Fix: maxOccurs of restriction within idsValue
The value has been limited to 1, this was a mistake in the schema
definition, it was alsways interpreted as 1 by the implementers.