### PR TITLE
added a generalized concept for version migration of IDS files via XSLT

### DIFF
--- a/Version migration/IDS_Audit_migration.xsl
+++ b/Version migration/IDS_Audit_migration.xsl
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+
+<!--
+ *
+ * Author: 			Marcel Stepien
+ * Organisation: 	VSK Software GmbH
+ * Date: 			2024.02.07
+ * e-Mail: 			info@vsk-software.com
+ * 
+ * Applies transformation of IDS developer agreements  changes from IDS 0.9.6 to 1.0.
+ *
+-->
+
+<xsl:stylesheet
+        xmlns:ids="http://standards.buildingsmart.org/IDS"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        version="1.0">
+
+    <xsl:output method="xml" indent="yes"/>
+    
+	<xsl:template match="node()|@*">
+	  <xsl:copy>
+	    <xsl:apply-templates select="node()|@*"/>
+	  </xsl:copy>
+	</xsl:template>
+	
+    <xsl:param
+	    name="lang_lower"
+	    select="'abcdefghijklmnopqrstuvwxyz'" />
+	    
+	<xsl:param
+	    name="lang_upper"
+	    select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
+	    
+	<!-- IDS-Audit: IFC2x3 schema hint in lower-case for the x only -->
+	<xsl:template match="ids:specification/@ifcVersion">
+	    <xsl:attribute name="ifcVersion">    	
+		   <xsl:value-of select="translate(., $lang_lower, $lang_upper)"/>
+	    </xsl:attribute>
+	</xsl:template>
+	
+	<!-- IDS-Audit: IFC entity names are printed in upper-case -->
+	<xsl:template match="ids:entity/ids:name/ids:simpleValue/text()">
+	   <xsl:value-of select="translate(., $lang_lower, $lang_upper)"/>
+	</xsl:template>
+	
+	<xsl:template match="ids:entity/ids:name/xs:restriction/xs:enumeration/@value">
+	    <xsl:attribute name="value">    	
+		   <xsl:value-of select="translate(., $lang_lower, $lang_upper)"/>
+	    </xsl:attribute>
+	</xsl:template>
+	
+	<!-- IDS-Audit: upper-case of datatype for version 0.9.6 -->
+	<xsl:template match="ids:property/@datatype">
+	    <xsl:attribute name="datatype">    	
+		   <xsl:value-of select="translate(., $lang_lower, $lang_upper)"/>
+	    </xsl:attribute>
+	</xsl:template>
+	
+	<!-- IDS-Audit: upper-case of dataType for version 0.9.7 -->
+	<xsl:template match="ids:property/@dataType">
+	    <xsl:attribute name="dataType">    	
+		   <xsl:value-of select="translate(., $lang_lower, $lang_upper)"/>
+	    </xsl:attribute>
+	</xsl:template>
+	
+	<!-- IDS-Audit: ensure that a base is provided for restrictions, but only if none is provided -->
+	<xsl:template match="xs:restriction[(./xs:minInclusive or ./xs:maxInclusive or ./xs:minExclusive or ./xs:maxExclusive) and not(@base)]">
+    	<xsl:copy>
+			<xsl:attribute name="base">xs:double</xsl:attribute>
+    		<xsl:apply-templates select="node()|@*"/>
+    	</xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="xs:restriction[(./xs:enumeration or ./xs:pattern) and not(@base)]">
+    	<xsl:copy>
+			<xsl:attribute name="base">xs:string</xsl:attribute>
+    		<xsl:apply-templates select="node()|@*"/>
+    	</xsl:copy>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/Version migration/IDS_v0.9.3-v0.9.6_migration.xsl
+++ b/Version migration/IDS_v0.9.3-v0.9.6_migration.xsl
@@ -48,7 +48,7 @@
 	</xsl:template>
 	
 	<!-- IDS-0.9.6: remove the min- and maxOccurs from the attribute facet -->
-    <xsl:template match="attribute/@minOccurs" />
-    <xsl:template match="attribute/@maxOccurs" />
+    <xsl:template match="ids:attribute/@minOccurs" />
+    <xsl:template match="ids:attribute/@maxOccurs" />
     
 </xsl:stylesheet>

--- a/Version migration/IDS_v0.9.3-v0.9.6_migration.xsl
+++ b/Version migration/IDS_v0.9.3-v0.9.6_migration.xsl
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+
+<!--
+ *
+ * Author: 			Marcel Stepien, Andre Vonthron
+ * Organisation: 	VSK Software GmbH
+ * Date: 			2024.01.23
+ * e-Mail: 			info@vsk-software.com
+ * 
+ * Applies transformation changes from IDS 0.9.3 to 0.9.6.
+ *
+-->
+
+<xsl:stylesheet
+        xmlns:ids="http://standards.buildingsmart.org/IDS"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        version="1.0">
+
+    <xsl:output method="xml" indent="yes"/>
+    
+	<xsl:template match="node()|@*">
+	  <xsl:copy>
+	    <xsl:apply-templates select="node()|@*"/>
+	  </xsl:copy>
+	</xsl:template>
+	
+    <xsl:param
+	    name="lang_lower"
+	    select="'abcdefghijklmnopqrstuvwxyz'" />
+	    
+	<xsl:param
+	    name="lang_upper"
+	    select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
+	    
+	<!-- IDS-0.9.6: all partOf relations to uppercase -->
+	<xsl:template match="@relation">
+	    <xsl:attribute name="relation">
+	        <xsl:value-of select="translate(., $lang_lower, $lang_upper)" />
+	    </xsl:attribute>
+	</xsl:template>
+    
+	<!-- IDS-0.9.6: renaming measure to datatype -->
+	<xsl:template match="@measure">
+	   <xsl:attribute name="datatype">
+	      <xsl:value-of select="."/>
+	   </xsl:attribute>
+	</xsl:template>
+	
+	<!-- IDS-0.9.6: remove the min- and maxOccurs from the attribute facet -->
+    <xsl:template match="attribute/@minOccurs" />
+    <xsl:template match="attribute/@maxOccurs" />
+    
+</xsl:stylesheet>

--- a/Version migration/IDS_v0.9.6-v0.9.7_migration.xsl
+++ b/Version migration/IDS_v0.9.6-v0.9.7_migration.xsl
@@ -1,0 +1,109 @@
+<?xml version="1.0"?>
+
+<!--
+ *
+ * Author: 			Marcel Stepien, Andre Vonthron
+ * Organisation: 	VSK Software GmbH
+ * Date: 			2024.03.03
+ * e-Mail: 			info@vsk-software.com
+ * 
+ * Applies transformation changes from IDS 0.9.6 to 0.9.7.
+ *
+-->
+
+<xsl:stylesheet
+        xmlns:ids="http://standards.buildingsmart.org/IDS"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        version="1.0">
+
+    <xsl:output method="xml" indent="yes"/>
+    
+	<xsl:template match="node()|@*">
+	  <xsl:copy>
+	    <xsl:apply-templates select="node()|@*"/>
+	  </xsl:copy>
+	</xsl:template>
+	
+	<!-- IDS-0.9.7: renaming property -> name to baseName -->
+    <xsl:template match="ids:property/ids:name">
+        <ids:baseName>
+        	<xsl:apply-templates select="@*|node()" />
+        </ids:baseName>
+    </xsl:template>
+	
+	<!-- IDS-0.9.7: renaming datatype to dataType -->
+	<xsl:template match="@datatype">
+	   <xsl:attribute name="dataType">
+	      <xsl:value-of select="."/>
+	   </xsl:attribute>
+	</xsl:template>
+	
+	<!-- 
+		IDS-0.9.7: remove the min- and maxOccurs from the attribute facet and
+		replace it with an enum of cardinalities of the interpreted occurs.
+	 -->
+    <xsl:template match="ids:requirements/*[@minOccurs = '1']">
+    	<xsl:copy>
+			<xsl:attribute name="cardinality">required</xsl:attribute>
+    		<xsl:apply-templates select="node()|@*"/>
+    	</xsl:copy>
+    </xsl:template>
+    <xsl:template match="ids:requirements/*[@minOccurs = '0' and @maxOccurs != '0']">
+    	<xsl:copy>
+			<xsl:attribute name="cardinality">optional</xsl:attribute>
+    		<xsl:apply-templates select="node()|@*"/>
+    	</xsl:copy>
+    </xsl:template>
+    <xsl:template match="ids:requirements/*[@minOccurs = '0' and @maxOccurs = '0']">
+    	<xsl:copy>
+			<xsl:attribute name="cardinality">prohibited</xsl:attribute>
+    		<xsl:apply-templates select="node()|@*"/>
+    	</xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="ids:requirements/*[@minOccurs != '0' and @minOccurs != '1']">
+    	<xsl:copy>
+			<xsl:attribute name="cardinality">required</xsl:attribute>
+    		<xsl:apply-templates select="node()|@*"/>
+    	</xsl:copy>
+    </xsl:template>
+    
+    <!-- removes the minOccurs and maxOccurs -->
+    <xsl:template match="ids:requirements/*/@minOccurs" />
+    <xsl:template match="ids:requirements/*/@maxOccurs" />
+    
+    
+	<!-- 
+		IDS-0.9.7: Adjustments to the partOf-facet. Including the removal of cardinality option of 'optional' (in replacement or required) and 
+		the merged combination of IFCRELAGGREGATES and IFCRELFILLSELEMENT to one combined option. 
+	-->
+    <xsl:template match="ids:requirements/ids:partOf[@cardinality = 'optional']">
+    	<xsl:copy>
+			<xsl:attribute name="cardinality">required</xsl:attribute>
+			<xsl:apply-templates select="node()|@*"/>
+			
+			<!--
+				Important note! 
+				Some xsl tranformer may require to exclude the modified attribute manually. 
+				In that case replace the line above with the line below.
+			-->
+    		<!--  <xsl:apply-templates select="node()|@* except @cardinality"/> -->
+    	</xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="ids:requirements/ids:partOf[@relation = 'IFCRELVOIDSELEMENT' or @relation = 'IFCRELFILLSELEMENT']">
+    	<xsl:copy>
+			<xsl:attribute name="relation">IFCRELVOIDSELEMENT IFCRELFILLSELEMENT</xsl:attribute>
+			<xsl:apply-templates select="node()|@*"/>
+			
+			<!--
+				Important note! 
+				Some xsl tranformer may require to exclude the modified attribute manually. 
+				In that case replace the line above with the line below.
+			-->
+    		<!-- <xsl:apply-templates select="node()|@* except @relation"/>  -->
+    	</xsl:copy>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/Version migration/README.md
+++ b/Version migration/README.md
@@ -7,3 +7,16 @@ A workflow using *Extensible Stylesheet Language Transformer* (XSLT) scripts is 
 The general naming convention of the migration files is as following:
 
 - **IDS_{old version}-{new version}_migration.xsl**
+
+Certain files may diverge in the naming convention, such as specialized transformations regardless of versions and order of migration. The scripts content are written based on XSLT 2.0 and XPath 2.0 language extensions. The following order of transformation is recommended for migration into newer versions: 
+
+1. IDS_v0.9.3-v0.9.6_migration 
+2. IDS_v0.9.6-v0.9.7_migration
+3. IDS_Audit_migration
+
+For execution of those XSLT-scripts, numerouse transformer are available online and hosted for free. On the coding side, developers may look into libraries such as:
+
+- Saxon 9 (Java, .NET, Native, JavaScript) ![feature list](https://www.saxonica.com/html/products/feature-matrix-9-9.html)
+- AltovaXML 2008 
+- Xalan-J (Java integration)
+- Xalan-C++ (C++ integration)

--- a/Version migration/README.md
+++ b/Version migration/README.md
@@ -1,0 +1,9 @@
+# Version migration
+
+This page primarily adresses the need for developers to migrate IDS versions.
+
+As a potential strategy to migrate older IDS files into newer versions a workflow using *Extensible Stylesheet Language Transformer* (XSLT) scripts is proposed. Each script formulates a distinct transformation for the IDS, changing updating naming conventions and the general structure of an IDS. Most common XSD/XML parser are able to use XSLT out of the box. How and when this transformation is dependent on individual use-cases. However, we recommend considering integrating the script pasing on load/upload, to enable consideration of older versions into newer applications. 
+
+The general naming convention of the migration files is as following:
+
+- **IDS_{old version}-{new version}_migration.xsl**


### PR DESCRIPTION
This first commit showcases a XSLT scripts for migration of IDS files defined in version 0.9.3 to version 0.9.6. This general concept of using XSLT for version migration will be recommended for handling breaking changes in future versions of IDS. All of this is maintained in a subfolder "Version migration" of the repository.