### PR TITLE
Update fail-an_optional_material_fails_if_no_value_matches.ifc

### DIFF
--- a/Documentation/testcases/material/fail-an_optional_material_fails_if_no_value_matches.ifc
+++ b/Documentation/testcases/material/fail-an_optional_material_fails_if_no_value_matches.ifc
@@ -6,7 +6,7 @@ FILE_SCHEMA(('IFC4'));
 ENDSEC;
 DATA;
 #1=IFCWALL('1hqIFTRjfV6AWq_bMtnZwI',$,$,$,$,$,$,$,$);
-#2=IFCMATERIAL("No match",$,$);
+#2=IFCMATERIAL('No match',$,$);
 #3=IFCRELASSOCIATESMATERIAL('05rScmOVzMoQXOfbYdtLYj',$,$,$,(#1),#2);
 ENDSEC;
 END-ISO-10303-21;


### PR DESCRIPTION
Fixes #267 

IFC file was manually edited using an illegal string literal token. (" vs ')