### PR TITLE
Update ids.xsd fix documentation link

### DIFF
--- a/Schema/ids.xsd
+++ b/Schema/ids.xsd
@@ -80,7 +80,7 @@
 				<xs:annotation>
 					<xs:documentation>
 						Depending on the dataType attribute, values are expressed in the default unit documented at 
-						https://github.com/buildingSMART/IDS/blob/master/Documentation/units.md, and unit conversion might be required.
+						https://github.com/buildingSMART/IDS/blob/master/Documentation/UserManual/units.md, and unit conversion might be required.
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
@@ -98,7 +98,7 @@
 				<xs:annotation>
 					<xs:documentation>
 						Depending on the IFC type of the attribute, values are expressed in the default unit documented at 
-						https://github.com/buildingSMART/IDS/blob/master/Documentation/units.md, and unit conversion might be required.
+						https://github.com/buildingSMART/IDS/blob/master/Documentation/UserManual/units.md, and unit conversion might be required.
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>


### PR DESCRIPTION
Two links in the documentation tags pointed to the wrong markdown file in the repository. "UserManual" folder had to be inserted.

https://github.com/buildingSMART/IDS/blob/master/Documentation/UserManual/units.md