### PR TITLE
Adding test cases for multiple patterns

### DIFF
--- a/Documentation/ImplementersDocumentation/TestCases/restriction/fail-regex_patterns_work_in_OR_3_3.ids
+++ b/Documentation/ImplementersDocumentation/TestCases/restriction/fail-regex_patterns_work_in_OR_3_3.ids
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>Regex patterns work in OR 3/3</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="Regex patterns work in OR 3/3" ifcVersion="IFC2X3 IFC4">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCWALL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <attribute>
+          <name>
+            <simpleValue>Name</simpleValue>
+          </name>
+          <value>
+            <xs:restriction base="xs:string">
+              <xs:pattern value="[a-z]{3}[0-9]{2}" />
+              <xs:pattern value="[A-Z]{3}[0-9]{2}" />
+            </xs:restriction>
+          </value>
+        </attribute>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/Documentation/ImplementersDocumentation/TestCases/restriction/fail-regex_patterns_work_in_OR_3_3.ifc
+++ b/Documentation/ImplementersDocumentation/TestCases/restriction/fail-regex_patterns_work_in_OR_3_3.ifc
@@ -1,0 +1,10 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2022-10-07T13:48:44',(),(),'IfcOpenShell v0.7.0-dc67287d','IfcOpenShell v0.7.0-dc67287d','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCWALL('1hqIFTRjfV6AWq_bMtnZwI',$,'XY99',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/Documentation/ImplementersDocumentation/TestCases/restriction/pass-regex_patterns_work_in_OR_1_3.ids
+++ b/Documentation/ImplementersDocumentation/TestCases/restriction/pass-regex_patterns_work_in_OR_1_3.ids
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>Regex patterns work in OR 1/3</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="Regex patterns work in OR 1/3" ifcVersion="IFC2X3 IFC4">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCWALL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <attribute>
+          <name>
+            <simpleValue>Name</simpleValue>
+          </name>
+          <value>
+            <xs:restriction base="xs:string">
+              <xs:pattern value="[A-Z]{2}[0-9]{2}" />
+              <xs:pattern value="[a-z]{2}[0-9]{2}" />
+            </xs:restriction>
+          </value>
+        </attribute>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/Documentation/ImplementersDocumentation/TestCases/restriction/pass-regex_patterns_work_in_OR_1_3.ifc
+++ b/Documentation/ImplementersDocumentation/TestCases/restriction/pass-regex_patterns_work_in_OR_1_3.ifc
@@ -1,0 +1,10 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2022-10-07T13:48:44',(),(),'IfcOpenShell v0.7.0-dc67287d','IfcOpenShell v0.7.0-dc67287d','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCWALL('1hqIFTRjfV6AWq_bMtnZwI',$,'XY99',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/Documentation/ImplementersDocumentation/TestCases/restriction/pass-regex_patterns_work_in_OR_2_3.ids
+++ b/Documentation/ImplementersDocumentation/TestCases/restriction/pass-regex_patterns_work_in_OR_2_3.ids
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>Regex patterns work in OR 2/3</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="Regex patterns work in OR 2/3" ifcVersion="IFC2X3 IFC4">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCWALL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <attribute>
+          <name>
+            <simpleValue>Name</simpleValue>
+          </name>
+          <value>
+            <xs:restriction base="xs:string">
+              <xs:pattern value="[a-z]{2}[0-9]{2}" />
+              <xs:pattern value="[A-Z]{2}[0-9]{2}" />
+            </xs:restriction>
+          </value>
+        </attribute>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/Documentation/ImplementersDocumentation/TestCases/restriction/pass-regex_patterns_work_in_OR_2_3.ifc
+++ b/Documentation/ImplementersDocumentation/TestCases/restriction/pass-regex_patterns_work_in_OR_2_3.ifc
@@ -5,6 +5,6 @@ FILE_NAME('','2022-10-07T13:48:44',(),(),'IfcOpenShell v0.7.0-dc67287d','IfcOpen
 FILE_SCHEMA(('IFC4'));
 ENDSEC;
 DATA;
-#1=IFCWALL('1hqIFTRjfV6AWq_bMtnZwI',$,'xy99',$,$,$,$,$,$);
+#1=IFCWALL('1hqIFTRjfV6AWq_bMtnZwI',$,'XY99',$,$,$,$,$,$);
 ENDSEC;
 END-ISO-10303-21;

--- a/Documentation/ImplementersDocumentation/TestCases/restriction/pass-regex_patterns_work_in_OR_2_3.ifc
+++ b/Documentation/ImplementersDocumentation/TestCases/restriction/pass-regex_patterns_work_in_OR_2_3.ifc
@@ -5,6 +5,6 @@ FILE_NAME('','2022-10-07T13:48:44',(),(),'IfcOpenShell v0.7.0-dc67287d','IfcOpen
 FILE_SCHEMA(('IFC4'));
 ENDSEC;
 DATA;
-#1=IFCWALL('1hqIFTRjfV6AWq_bMtnZwI',$,'XY99',$,$,$,$,$,$);
+#1=IFCWALL('1hqIFTRjfV6AWq_bMtnZwI',$,'xy99',$,$,$,$,$,$);
 ENDSEC;
 END-ISO-10303-21;

--- a/Documentation/ImplementersDocumentation/TestCases/restriction/pass-regex_patterns_work_in_OR_2_3.ifc
+++ b/Documentation/ImplementersDocumentation/TestCases/restriction/pass-regex_patterns_work_in_OR_2_3.ifc
@@ -1,0 +1,10 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2022-10-07T13:48:44',(),(),'IfcOpenShell v0.7.0-dc67287d','IfcOpenShell v0.7.0-dc67287d','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCWALL('1hqIFTRjfV6AWq_bMtnZwI',$,'XY99',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/Documentation/ImplementersDocumentation/TestCases/scripts.md
+++ b/Documentation/ImplementersDocumentation/TestCases/scripts.md
@@ -2632,6 +2632,33 @@ Requirements:
 Attribute: ''Name'',Pattern(''[A-Z]{2}[0-9]{2}'')
 ```
 
+### Regex patterns work in OR 1/3
+
+``` ids restriction/pass-regex_patterns_work_in_OR_1_3.ids
+Regex patterns work in OR 1/3
+Entity: ''IFCWALL''
+Requirements:
+Attribute: ''Name'',Pattern(''[A-Z]{2}[0-9]{2}'') Pattern(''[a-z]{2}[0-9]{2}'')
+```
+
+### Regex patterns work in OR 2/3
+
+``` ids restriction/pass-regex_patterns_work_in_OR_2_3.ids
+Regex patterns work in OR 2/3
+Entity: ''IFCWALL''
+Requirements:
+Attribute: ''Name'',Pattern(''[a-z]{2}[0-9]{2}'') Pattern(''[A-Z]{2}[0-9]{2}'')
+```
+
+### Regex patterns work in OR 3/3
+
+``` ids restriction/fail-regex_patterns_work_in_OR_3_3.ids
+Regex patterns work in OR 3/3
+Entity: ''IFCWALL''
+Requirements:
+Attribute: ''Name'',Pattern(''[a-z]{3}[0-9]{2}'') Pattern(''[A-Z]{3}[0-9]{2}'')
+```
+
 ## tolerance
 
 ### Comparison tolerance for floating point positive high number lower bound pass


### PR DESCRIPTION
One restriction can contain multiple regexes.
They need to be evaluated in OR between them and in AND with any other.

Fixes #285