### PR TITLE
Fixed mapping of IfcUriReference to backing type

### DIFF
--- a/Documentation/ImplementersDocumentation/DataTypes.md
+++ b/Documentation/ImplementersDocumentation/DataTypes.md
@@ -373,7 +373,7 @@ Columns of the table determine the validity of the type depending on the schema 
 | IFCUNITARYCONTROLELEMENTTYPEENUM              |         |    ✓    |    ✓    | xs:string             |
 | IFCUNITARYEQUIPMENTTYPEENUM                   |    ✓    |    ✓    |    ✓    | xs:string             |
 | IFCUNITENUM                                   |    ✓    |    ✓    |    ✓    | xs:string             |
-| IFCURIREFERENCE                               |         |    ✓    |    ✓    | xs:anyUri             |
+| IFCURIREFERENCE                               |         |    ✓    |    ✓    | xs:anyURI             |
 | IFCVALVETYPEENUM                              |    ✓    |    ✓    |    ✓    | xs:string             |
 | IFCVAPORPERMEABILITYMEASURE                   |    ✓    |    ✓    |    ✓    | xs:double             |
 | IFCVEHICLETYPEENUM                            |         |         |    ✓    | xs:string             |
@@ -408,7 +408,7 @@ The list of valid XML base types for the `base` attribute of `xs:restriction`, t
 
 | Base type   | Value string regex constraint                                                                                                         | annotation    | pattern       | enumeration   | minLength     | maxLength     | length        | minExclusive  | maxExclusive  | minInclusive  | maxInclusive  |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: |
-| xs:anyUri   | <code>^\S+$</code>                                                                                                                    |       ✓       |       ✓       |       ✓       |       ✓       |       ✓       |       ✓       |               |               |               |               |
+| xs:anyURI   | <code>^\S+$</code>                                                                                                                    |       ✓       |       ✓       |       ✓       |       ✓       |       ✓       |       ✓       |               |               |               |               |
 | xs:boolean  | <code>^(true&#124;false&#124;0&#124;1)$</code>                                                                                        |       ✓       |       ✓       |               |               |               |               |               |               |               |               |
 | xs:date     | <code>^\d{4}-\d{2}-\d{2}(Z&#124;(&#91;+-&#93;\d{2}:\d{2}))?$</code>                                                                   |       ✓       |       ✓       |       ✓       |               |               |               |       ✓       |       ✓       |       ✓       |       ✓       |
 | xs:dateTime | <code>^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z&#124;(&#91;+-&#93;\d{2}:\d{2}))?$</code>                                         |       ✓       |       ✓       |       ✓       |               |               |               |       ✓       |       ✓       |       ✓       |       ✓       |

--- a/Documentation/ImplementersDocumentation/DataTypes.md
+++ b/Documentation/ImplementersDocumentation/DataTypes.md
@@ -279,7 +279,7 @@ Columns of the table determine the validity of the type depending on the schema 
 | IFCRATIOMEASURE                               |    ✓    |    ✓    |    ✓    | xs:double             |
 | IFCREAL                                       |    ✓    |    ✓    |    ✓    | xs:double             |
 | IFCRECURRENCETYPEENUM                         |         |    ✓    |    ✓    | xs:string             |
-| IFCREFERENTTYPEENUM                           |         |    ✓    |    ✓    | xs:string             |
+| IFCREFERENTTYPEENUM                           |         |         |    ✓    | xs:string             |
 | IFCREFLECTANCEMETHODENUM                      |    ✓    |    ✓    |    ✓    | xs:string             |
 | IFCREINFORCEDSOILTYPEENUM                     |         |         |    ✓    | xs:string             |
 | IFCREINFORCINGBARROLEENUM                     |    ✓    |    ✓    |    ✓    | xs:string             |
@@ -373,7 +373,7 @@ Columns of the table determine the validity of the type depending on the schema 
 | IFCUNITARYCONTROLELEMENTTYPEENUM              |         |    ✓    |    ✓    | xs:string             |
 | IFCUNITARYEQUIPMENTTYPEENUM                   |    ✓    |    ✓    |    ✓    | xs:string             |
 | IFCUNITENUM                                   |    ✓    |    ✓    |    ✓    | xs:string             |
-| IFCURIREFERENCE                               |         |    ✓    |    ✓    | xs:string             |
+| IFCURIREFERENCE                               |         |    ✓    |    ✓    | xs:anyUri             |
 | IFCVALVETYPEENUM                              |    ✓    |    ✓    |    ✓    | xs:string             |
 | IFCVAPORPERMEABILITYMEASURE                   |    ✓    |    ✓    |    ✓    | xs:double             |
 | IFCVEHICLETYPEENUM                            |         |         |    ✓    | xs:string             |
@@ -408,6 +408,7 @@ The list of valid XML base types for the `base` attribute of `xs:restriction`, t
 
 | Base type   | Value string regex constraint                                                                                                         | annotation    | pattern       | enumeration   | minLength     | maxLength     | length        | minExclusive  | maxExclusive  | minInclusive  | maxInclusive  |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: |
+| xs:anyUri   | <code>^\S+$</code>                                                                                                                    |       ✓       |       ✓       |       ✓       |       ✓       |       ✓       |       ✓       |               |               |               |               |
 | xs:boolean  | <code>^(true&#124;false&#124;0&#124;1)$</code>                                                                                        |       ✓       |       ✓       |               |               |               |               |               |               |               |               |
 | xs:date     | <code>^\d{4}-\d{2}-\d{2}(Z&#124;(&#91;+-&#93;\d{2}:\d{2}))?$</code>                                                                   |       ✓       |       ✓       |       ✓       |               |               |               |       ✓       |       ✓       |       ✓       |       ✓       |
 | xs:dateTime | <code>^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z&#124;(&#91;+-&#93;\d{2}:\d{2}))?$</code>                                         |       ✓       |       ✓       |       ✓       |               |               |               |       ✓       |       ✓       |       ✓       |       ✓       |

--- a/Documentation/UserManual/specifications.md
+++ b/Documentation/UserManual/specifications.md
@@ -28,6 +28,7 @@ A **Facet** describes its information precisely using fixed **Facet Parameters**
 When a **Facet** is used in the **Applicability** section, it describes the information that we use to identify the relevant parts of the model.
 
 When a **Facet** is used in the **Requirements** section, it describes the information constraints that the model parts must fulfill to comply with the **Specification**.
+Each facet in the requirements can be enriched with an optional `instructions` text to help end-users complete the model.
 
 ![IDS Structure](Graphics/ids-structure.png)
 


### PR DESCRIPTION
This PR recognises the specific xs:anyUri type for IfcUriReference.

It also makes URI's regex more specific, while still loose. 

Also, a minor  minor comment is added in the specifications.md, to introduce the existence of `Instructions` for facets associated with requirements.