### PR TITLE
Docs: state that IDS regex patterns match the whole value

### DIFF
--- a/Documentation/UserManual/restrictions.md
+++ b/Documentation/UserManual/restrictions.md
@@ -45,6 +45,12 @@ Here are some common examples you can use:
 
 Note that Regex has multiple "flavours" or "dialects", so although the first two links are useful learning resources, they may also include Regex features not available in IDS. The third link (XML Regular expressions) can be referenced as an authoritative source on what can be used in IDS. In general, Regex in IDS is simpler and does not include advanced Regex features.
 
+One flavour difference is worth calling out on its own, because it does not cause an error, it silently changes the result. **IDS patterns must match the whole value, not part of it.** Every example in the table above relies on this. `DT[0-9]` rejects "`DT123`" precisely because the pattern has to account for the entire value, not just find "`DT1`" inside it.
+
+Most general purpose Regex testers, including regex101.com, search for a *matching part* of the value instead. Testing `DT[0-9]` against "`DT123`" there reports a match, which is the opposite of what IDS does. To reproduce IDS behaviour in such a tool, wrap the pattern in `^` and `$`, for example `^DT[0-9]$`. **Do not copy those anchors back into the IDS pattern**, they are not needed and `^` and `$` are not part of the XML Schema Regex syntax.
+
+Testers that implement XML Schema Regex directly avoid this problem, since they apply whole value matching automatically. Two free online examples are [DevToys XSD Regex Tester](https://devtoys.pro/testers/xsd-regex) and [Xsd Pattern Tester](https://online-xsd-pattern.vercel.app/). These are third party tools and are not affiliated with buildingSMART.
+
 ## Bounds
 
 A **Bounds** restriction allows you to specify that the value is a number and has to fall within a range of values. You can specify either a minimum, maximum, or both. You can also specify whether the minimum or maximum is inclusive (e.g. `>=` and `<=`) or exclusive (e.g. `>` and `<`). For example, you might specify that a value needs to be "more than 3" and "less than or equal to 10".


### PR DESCRIPTION
The Restrictions page links regex101.com as a learning resource. Regex101 does not implement the XML Schema Regex flavour that IDS uses, and one difference in particular does not produce an error, it silently returns the opposite answer.

## The page's own example contradicts the tool it links

The existing table says `DT[0-9]` rejects "`DT123`". That is correct, and it is correct **because IDS patterns must match the whole value**. Tested with `xmlschema`, the library IfcTester uses to evaluate IDS patterns:

| Pattern | Value | IDS (XML Schema) | regex101 style search |
|---|---|---|---|
| `DT[0-9]` | `DT123` | **fails** (as the docs say) | **match** |
| `.{0,10}` | `WALL-EXTERNAL` | **fails** | **match** |
| `.{0,10}` | `DOOR-01-A2` | passes | match |

So a reader who checks the documentation's own example in the tool the documentation recommends is told the opposite of what the documentation says. For a length constraint like `.{0,10}` the effect is worse, because the pattern appears to accept values that IDS will reject, and nothing signals that anything is wrong.

## What this PR changes

The page already notes that flavours differ and points to XML Regular Expressions as authoritative, which is good. This adds the one specific difference that fails silently:

- states plainly that IDS patterns match the whole value, and points out that the existing table already depends on this
- explains how to reproduce IDS behaviour in a general purpose tester by wrapping the pattern in `^` and `$`
- warns not to copy those anchors back into the IDS pattern, since `^` and `$` are not part of XML Schema Regex

It also mentions two free online testers that implement XML Schema Regex directly, so the anchoring is handled automatically.

## On the two tools, so maintainers can judge

They are third party and not affiliated with buildingSMART, and the text says so.

- **DevToys XSD Regex Tester** — I checked its stated behaviour: it uses the `xspattern` library and documents that XSD patterns match the entire string by default. I have not independently audited its output.
- **Xsd Pattern Tester** — free and online, but it is a client side app and I could not verify its behaviour or find its source, so it is offered as an option rather than a recommendation.

**If linking third party tools is not appropriate here, the anchoring explanation stands on its own** and I am happy to drop the tool paragraph entirely. That is the part that matters; the tools are a convenience.

Happy to reword any of this to fit the manual's voice.
