### PR TITLE
Document why compound measures are absent from DataTypes (#297)

### DIFF
--- a/Documentation/ImplementersDocumentation/DataTypes.md
+++ b/Documentation/ImplementersDocumentation/DataTypes.md
@@ -402,6 +402,8 @@ Columns of the table determine the validity of the type depending on the schema 
 
 Please note that [IFCSTRIPPEDOPTIONAL](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcStrippedOptional.htm) is a special data type that should never be instantiated, but it is listed here for schema tolerance reasons.
 
+`IFCCOMPOUNDPLANEANGLEMEASURE` and `IFCCOMPLEXNUMBER` are intentionally absent from this table. Unlike every other measure, both are declared as aggregates in the IFC schema (`IfcCompoundPlaneAngleMeasure` is a `LIST [3:4] OF INTEGER` holding degrees, minutes, seconds and optionally millionths of a second; `IfcComplexNumber` is an `ARRAY [1:2] OF REAL`), so neither reduces to the single scalar value an `xs:restriction` requires and no `xs:base` type applies. Their data type can still be required on a property facet, for example `dataType="IFCCOMPOUNDPLANEANGLEMEASURE"`, to assert that a property exists with the correct IFC type. Only value level restriction is unsupported for these two.
+
 ## XML base types
 
 The list of valid XML base types for the `base` attribute of `xs:restriction`, the associated regex expression to check for the validity of string representation, and the allowed nodes inside the `xs:restriction` are as follows:


### PR DESCRIPTION
Addresses #297.

## The omission is correct, and worth saying so

@MatthiasWeise asked whether `IfcCompoundPlaneAngleMeasure`'s absence from the datatype table is intentional. It is, and for a structural reason that is easy to re-derive but currently written down nowhere, so the next reader will ask the same question.

Verified against the schema in IFC2X3, IFC4 and IFC4X3_ADD2:

```
IfcCompoundPlaneAngleMeasure   list [3:4] of integer
IfcComplexNumber               array [1:2] of real
IfcPlaneAngleMeasure           real                    (present in the table)
```

The table's stated job is to give each usable data type its `xs:base` type for `xs:restriction` purposes. An aggregate has no single scalar value to restrict, so no base type applies.

This is a consistent rule rather than an oversight. Enumerating every aggregate-declared type across all three schema versions gives `IfcComplexNumber`, `IfcCompoundPlaneAngleMeasure`, `IfcArcIndex`, `IfcLineIndex` and `IfcPropertySetDefinitionSet`, and **all five are absent, in every version, without exception**. The only scalar measure missing is none: everything else absent with "Measure" in its name is an abstract SELECT type rather than a usable data type.

## On @aothms's point

He noted that even where the value cannot be constrained, it should still be possible to require the data type. That already works. Measured against IfcOpenShell's IfcTester with an `IfcWall` carrying `Pset_Alignment.Bearing = IfcCompoundPlaneAngleMeasure(12,34,56)`:

```
dataType="IFCCOMPOUNDPLANEANGLEMEASURE"        PASS
dataType="IFCLABEL"                            FAIL, "does not match the required data type"
plus a simpleValue restriction on top          FAIL, does not silently pass
```

So the capability exists and discriminates correctly. The note records that too, since it is the practical answer to the original question.

## Scope

Prose only, no table rows changed. The table is generated from the audit tool repository, but the surrounding prose is hand maintained in the same file, following the existing `IFCSTRIPPEDOPTIONAL` note directly above this insertion.

@CBenghi noted in the thread that the audit tool and documentation would both be updated; this covers the documentation half only.

This PR was created with the assistance of an AI coding tool.
