### PR TITLE
chore: Updated Repository Automation to support net9 tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,27 @@
-2021 Detailed Project Plan/2021 IDS detailed project plan.docx
-/RepositoryAutomation/build/bin
-/RepositoryAutomation/build/obj/
+# User files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+build/
+bld/
+[Bb]in/
+[Oo]bj/
+
+# Visual Studo 2015 cache/options directory
+.vs/
 .vscode/
 .tmp/
-/RepositoryAutomation/build/.vs/
-**/.nuke/temp/
-/.vs/
-/RepositoryAutomation/SchemaProject/.vs/
-/RepositoryAutomation/SchemaProject/bin/
-/RepositoryAutomation/SchemaProject/obj/
-/RepositoryAutomation/SchemaProject/Ids.cs
+
 .DS_Store
+
+**/.nuke/temp/
+/RepositoryAutomation/SchemaProject/Ids.cs

--- a/RepositoryAutomation/SchemaProject/SchemaProject.csproj.user
+++ b/RepositoryAutomation/SchemaProject/SchemaProject.csproj.user
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ActiveDebugProfile>single ids renamed</ActiveDebugProfile>
-  </PropertyGroup>
-</Project>

--- a/RepositoryAutomation/build/Properties/launchSettings.json
+++ b/RepositoryAutomation/build/Properties/launchSettings.json
@@ -8,6 +8,10 @@
       "commandName": "Project",
       "commandLineArgs": "CreateTestCases"
     },
+    "AuditAllIdsFiles": {
+      "commandName": "Project",
+      "commandLineArgs": "AuditAllIdsFiles"
+    },
     "Standard run": {
       "commandName": "Project"
     },

--- a/RepositoryAutomation/build/_build.csproj
+++ b/RepositoryAutomation/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="8.1.4" />
+    <PackageReference Include="Nuke.Common" Version="9.0.4" />
     <PackageReference Include="ids-tool.CommandLine" Version="1.0.121" />
     <PackageDownload Include="dotnet-xscgen" Version="[2.1.1182]" />
   </ItemGroup>

--- a/RepositoryAutomation/build/_build.csproj
+++ b/RepositoryAutomation/build/_build.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="8.1.4" />
-    <PackageReference Include="ids-tool.CommandLine" Version="1.0.86" />
+    <PackageReference Include="ids-tool.CommandLine" Version="1.0.121" />
     <PackageDownload Include="dotnet-xscgen" Version="[2.1.1182]" />
   </ItemGroup>
   

--- a/RepositoryAutomation/build/_build.csproj.user
+++ b/RepositoryAutomation/build/_build.csproj.user
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ActiveDebugProfile>CreateTestCases</ActiveDebugProfile>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
Addresses #460 

I didn't go to .net10 as there are security advisories in the 10.x version of Nuke, and net9 has the identical support cycle as net10 so offers little advantage.

Also did some minor editing to .gitignore to make more standard/maintainable.